### PR TITLE
changed check for Joomla task request var to use JInput library method

### DIFF
--- a/mte.php
+++ b/mte.php
@@ -34,7 +34,7 @@ require_once 'mte.civix.php';
  */
 function mte_civicrm_config(&$config) {
   _mte_civix_civicrm_config($config);
-  if ($config->userFramework == 'Joomla' && 'civicrm/ajax/mte/callback' == $_GET['task']) {
+  if ($config->userFramework == 'Joomla' && 'civicrm/ajax/mte/callback' == JFactory::getApplication()->input->get('task')) {
     $_SESSION['mte_temp'] = 1; 
   }
 }


### PR DESCRIPTION
In Joomla 3.2.3, the use of $_GET['task'] in mte.php produced an PHP error. In addition, use of the JInput library does extra screening of input variables for security. Since this condition was already checking to see if the CMS is Joomla, it seems appropriate to use the framework method here.
