### PR TITLE
BRES-103

### DIFF
--- a/mte.php
+++ b/mte.php
@@ -208,6 +208,7 @@ function mte_civicrm_alterMailParams(&$params) {
   $session   = CRM_Core_Session::singleton();
   $userID = $session->get('userID');
   $activityTypes = CRM_Core_PseudoConstant::activityType(TRUE, FALSE, FALSE, 'name');
+  $params['toEmail'] = trim($params['toEmail']); // BRES-103 Prevent silent failure when emails with whitespaces are used.
   if (!$userID) {
     $config = CRM_Core_Config::singleton();
     if (version_compare($config->civiVersion, '4.3.alpha1') < 0) {


### PR DESCRIPTION
Bug: Whitespaces specified when multiple emails are separated with commas cause silent failure in the CRM_Core_DAO::getFieldValue function

Fix: Trimmed whitespaces off the toEmails.
