### PR TITLE
Add extension purpose, remove deprecated note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,7 @@
-biz.jmaconsulting.mte version 2.0 for CiviCRM 4.2 - 4.7
-=======================================================
+biz.jmaconsulting.mte - Mandrill Emails Extension for CiviCRM
+=============================================================
 
-Mandrill Emails Extension for CiviCRM
-
-See https://github.com/JMAConsulting/biz.jmaconsulting.mte/wiki/About-Mandrill-Emails-Extension-for-CiviCRM
-
-Note: Support for this extension is deprecated, and will be discontinued December 31, 2016. Co-maintainer interested in taking over support for extension is welcomed.
+This CiviCRM extension creates an Activity for each email sent to a person, and processes responses from Mandrill arising from them using a unique tracking identifier inserted into a custom email header, as well as adding support for click-through tracking, deliveries and message views ("opens"). This extension was previously named Mandrill Transactional Emails.
 
 Installation instructions for Mandrill Emails Extension
 =======================================================


### PR DESCRIPTION
Per https://chat.civicrm.org/civicrm/pl/uchwue5dbb8pmq3kzykg85j3gw, this extension is still supported so I figured it makes sense to remove the note saying it's deprecated which led me to misinform someone in the linked thread recently.

Also copied the text from the wiki link back here (since the wiki link only added that sentence then linked back to the README), and turned it into a "here's why the extension is useful" intro paragraph.