### PR TITLE
fix #105 - exclude the webhook URL from IDS checks

### DIFF
--- a/mte.php
+++ b/mte.php
@@ -585,3 +585,11 @@ function mte_civicrm_postEmailSend(&$params) {
     CRM_Mte_BAO_MandrillActivity::create($mandrillActivityParams);
   }
 }
+/**
+ * Implementation of hook_civicrm_idsException().
+ *
+ * Prevent values on my form from being processed by the IDS
+ */
+function mte_civicrm_idsException(&$skip) {
+  $skip[] = 'civicrm/ajax/mte/callback';
+}


### PR DESCRIPTION
This adds IDS skip hook implementation so that IDS checks are not performed for the JSON endpoint.