### PR TITLE
ignore first alter call for messageTemplate

### DIFF
--- a/mte.php
+++ b/mte.php
@@ -235,7 +235,7 @@ function mte_civicrm_alterMailParams(&$params, $context = null) {
   if (!in_array($context, array('civimail', 'flexmailer'))) {
     CRM_Core_Smarty::singleton()->assign('alterMailer', 'ignore');
   }
-  if (!mte_checkSettings($context)) {
+  if (!mte_checkSettings($context) || $context == 'messageTemplate') {
     return false;
   }
   $session = CRM_Core_Session::singleton();


### PR DESCRIPTION
https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_alterMailParams/#:~:text=Note%20that%20this%20hook%20is%20called%20twice%20when%20sending%20a%20message%20template%2C%20once%20early%20in%20the%20message%20generation%20(before%20tokens%20are%20applied%2C%20with%20the%20context%20messageTemplate)%20and%20then%20later%20from%20CRM_Utils_Mail%3A%3Asend()%20with%20the%20context%20singleEmail

I don't know if calling alterMailParams() twice is new behavior, or if the contents for $params has changed when context == messageTemplate. If alterMailParams() runs in this context, it ultimately fails trying to create a mailing event queue without a contact ID, and no message is sent or activities created. Ignoring this context solves the problem.